### PR TITLE
Add support for dictionary nested values

### DIFF
--- a/drf_renderer_xlsx/renderers.py
+++ b/drf_renderer_xlsx/renderers.py
@@ -190,8 +190,8 @@ class XLSXRenderer(BaseRenderer):
                 items.extend(self._flatten(v, new_key, sep=sep).items())
             elif isinstance(v, Iterable) and not isinstance(v, str):
                 # In case the value is an array it will be ignored 
-                # as it cannot be flatten into a xlsx colunm due to variety
-                # the number of columns per item
+                # as it cannot be flatten into a xlsx column due to
+                # the number of columns per item being variable
                 continue
             else:
                 items.append((new_key, v))


### PR DESCRIPTION
This feature enables the usage of serializers that contain nested objects, such as:

```javascript
{
  "name": "John", 
  "age": 28, 
  "location": {
    "city": "Philadelphia", 
    "country": "United States"
  }
}
```

Which will then translate into the XLSX file column names:
```
[ name | age | location.city | location.country ]
```

This feature will improve the support for Model relations with Foreign Keys