### PR TITLE
Added iterables in flatten to item list

### DIFF
--- a/drf_renderer_xlsx/renderers.py
+++ b/drf_renderer_xlsx/renderers.py
@@ -182,17 +182,14 @@ class XLSXRenderer(BaseRenderer):
             return False
         return True
 
-    def _flatten(self, data, parent_key='', sep='.'):
+    def _flatten(self, data, parent_key='', sep=','):
         items = []
         for k, v in data.items():
             new_key = f"{parent_key}{sep}{k}" if parent_key else k
             if isinstance(v, MutableMapping):
                 items.extend(self._flatten(v, new_key, sep=sep).items())
             elif isinstance(v, Iterable) and not isinstance(v, str):
-                # In case the value is an array it will be ignored 
-                # as it cannot be flatten into a xlsx column due to
-                # the number of columns per item being variable
-                continue
+                items.append((new_key, sep.join(v)))
             else:
                 items.append((new_key, v))
         return dict(items)


### PR DESCRIPTION
From my viewpoint it's required to return lists also as a separated list.

If possible please take the change to next release so that i can use it via pip in my project :-)