### PR TITLE
Fix IndexError on empty Iterable fields

### DIFF
--- a/drf_renderer_xlsx/renderers.py
+++ b/drf_renderer_xlsx/renderers.py
@@ -177,7 +177,7 @@ class XLSXRenderer(BaseRenderer):
             if isinstance(v, MutableMapping):
                 items.extend(self._flatten(v, new_key, key_sep=key_sep).items())
             elif isinstance(v, Iterable) and not isinstance(v, str):
-                if isinstance(v[0], Iterable):
+                if len(v) > 0 and isinstance(v[0], Iterable):
                     # array of array; write as json
                     items.append((new_key, json.dumps(v)))
                 else:


### PR DESCRIPTION
The `XLSXRenderer` is referencing `v[0]` before checking if `v[0]` exists. The PR adds a length check to avoid an IndexError when empty arrays are the value of a field after serialization.