### PR TITLE
Fix bug with Mixin applying to HttpResponse 

### DIFF
--- a/drf_renderer_xlsx/mixins.py
+++ b/drf_renderer_xlsx/mixins.py
@@ -1,3 +1,6 @@
+from rest_framework.response import Response
+
+
 class XLSXFileMixin(object):
     """
     Mixin which allows the override of the filename being
@@ -20,7 +23,7 @@ class XLSXFileMixin(object):
         response = super(XLSXFileMixin, self).finalize_response(
             request, response, *args, **kwargs
         )
-        if response.accepted_renderer.format == "xlsx":
+        if isinstance(response, Response) and response.accepted_renderer.format == "xlsx":
             response["content-disposition"] = "attachment; filename={}".format(
                 self.get_filename(),
             )


### PR DESCRIPTION
Applying the `XLSXFileMixin` to a view set also applies the mixin to any additional created actions. It is possible for these actions to return Django `HttpResponse` objects instead of Django Rest Framework `Response` objects. This PR prevents an error from occurring when a raw `HttpResponse` object is returned.

Example action that returns an HttpResponse:
```python
@action(detail=True, methods=['get'])
def qr(self, request, *args, **kwargs):
    """
    Return a QR code png image.
    """
    response = HttpResponse(content_type='image/png')
    # code to populate response object with QR code image here
    return response
```

Without this fix, accessing this endpoint will result in an `AttributeError: 'HttpResponse' object has no attribute 'accepted_renderer'`.