### PR TITLE
fixes a bug that caused loss of ancestor of parent field in _flatten_…

### DIFF
--- a/drf_renderer_xlsx/renderers.py
+++ b/drf_renderer_xlsx/renderers.py
@@ -242,7 +242,7 @@ class XLSXRenderer(BaseRenderer):
                     _header_dict.update(
                         self._flatten_serializer_keys(
                             v,
-                            k,
+                            new_key,
                             _get_label(parent_label, label_sep, v),
                             key_sep,
                             list_sep,
@@ -253,7 +253,10 @@ class XLSXRenderer(BaseRenderer):
                 else:
                     _header_dict.update(
                         self._flatten_serializer_keys(
-                            v, k, key_sep=key_sep, list_sep=list_sep
+                            v,
+                            new_key,
+                            key_sep=key_sep,
+                            list_sep=list_sep,
                         )
                     )
             elif isinstance(v, Field):


### PR DESCRIPTION
Fixes a problem that happened while flattening headers from nested serialisers. Example response:
```json
{
   "address": {
      "client": {
         "name": "foo",
         "id": 1
   }
}
```
Renderer put only client.name and client.id to header names. And returned empty data for those fields. This PR fixes this.