### PR TITLE
Added support to format dict to custom columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,44 @@ xlsx_date_format_mappings = {
 ```
 
 
+## Custom columns
+
+You might find yourself explicitly returning a dict in your API response and would like to use its data to display additional columns. This can be done by passing `xlsx_custom_cols`.
+```
+xlsx_custom_cols = {
+    'my_custom_col.val1.title': {
+        'label': 'Custom column!',
+        'formatter': custom_value_formatter
+    }
+}
+
+# Example function:
+def custom_value_formatter(val):
+    return val + '!!!'
+
+# Example response:
+{ 
+    results: [
+        {
+            title: 'XLSX renderer',
+            url: 'https://github.com/wharton/drf-renderer-xlsx'
+            returned_dict: {
+                val1: {
+                    title: 'Sometimes'
+                },
+                val2: {
+                    title: 'There is no way around'
+                }
+            }
+        }
+    ]
+}
+```
+
+When no `label` is passed, `drf-renderer-xlsx` will display the key name in the header.
+`formatter` is also optional and accepts a function, which will then receive the value it is mapped to (it would receive "Sometimes" and return "Sometimes!!!" in our example).
+
+
 ## Custom mappings
 
 Assuming you have a field that returns a `dict` instead of a simple `str`, you might not want to return the whole object but only a value of it. Let's say `status` returns `{ value: 1, display: 'Active' }`. To return the `display` value in the `status` column, we can do this:


### PR DESCRIPTION
I am not completely sure how much of an edge-case this is, but I ended up having to return a pretty large dict (through `to_representation`) which has values that I needed to also display in individual columns. This adds support for that.