### PR TITLE
Support DateField for xlsx_date_format_mappings

### DIFF
--- a/drf_renderer_xlsx/renderers.py
+++ b/drf_renderer_xlsx/renderers.py
@@ -1,7 +1,7 @@
 import json
 
 from collections.abc import MutableMapping, Iterable
-from django.utils.dateparse import parse_datetime
+from django.utils.dateparse import parse_datetime, parse_date
 from openpyxl import Workbook
 from openpyxl.styles import PatternFill, Border, Side, Alignment, Font, NamedStyle
 from openpyxl.drawing.image import Image
@@ -268,6 +268,8 @@ class XLSXRenderer(BaseRenderer):
             if self.date_format_mappings and key in self.date_format_mappings:
                 try:
                     date = parse_datetime(value)
+                    if date is None:
+                        date = parse_date(value)
                     items.append((key, date.strftime(self.date_format_mappings[key])))
                     return
                 except TypeError:


### PR DESCRIPTION
parse_datetime(value) returns None if the value is just a date and then the strftime fails. So now also try date_parse.